### PR TITLE
Update chart-release.yaml

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,9 +1,11 @@
 name: Release Helm Chart
 
 on:
-    push:
-      branches:
-        - main
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
Skip release if only README changed.

This will avoid build failures like the most recent one.