### PR TITLE
release 0.2.0

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: "latest"
-version: 0.1.2
+version: 0.2.0
 name: localstack
 description: A fully functional local AWS cloud stack
 type: application


### PR DESCRIPTION
Bump the version; chart-releaser is currently failing because of a tag conflict.