### PR TITLE
fix: fix typo about containerPort

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.1.3
+version: 0.1.4
 name: localstack
 description: A fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the Localstack chart an
 
 ## Change Log
 
+* v0.1.4: Fix a typo that breaks the installation
 * v0.1.3: Allow easy exposure of multiple API services from values config
 
 ## License

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: {{ .Values.service.edgeService.name }}
-              container: {{ .Values.service.edgeService.targetPort }}
+              containerPort: {{ .Values.service.edgeService.targetPort }}
               protocol: TCP
             {{- range .Values.service.apiServices }}
             - name: {{ .name }}


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

The latest version (0.1.3) of helm chart could not work.

Helm report that error:
```
$ helm upgrade --install localstack localstack-repo/localstack
"localstack-repo" has been added to your repositories
Release "localstack" does not exist. Installing it now.
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Deployment.spec.template.spec.containers[0].ports[0]): unknown field "container" in io.k8s.api.core.v1.ContainerPort, ValidationError(Deployment.spec.template.spec.containers[0].ports[0]): missing required field "containerPort" in io.k8s.api.core.v1.ContainerPort]
```

I think this typo breaks the installation.