### PR TITLE
Make livenessProbe/readinessProbe configurable

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.1.3
+version: 0.1.4
 name: localstack
 description: A fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -81,6 +81,10 @@ The following table lists the configurable parameters of the Localstack chart an
 | `affinity`                                           | Affinity for pod assignment                                                                                                                                                                                                           | `{}`                                                    |
 | `resources.limits`                                   | The resources limits for Localstack containers                                                                                                                                                                                        | `{}`                                                    |
 | `resources.requests`                                 | The requested resources for Localstack containers                                                                                                                                                                                     | `{}`                                                    |
+| `livenessProbe`                                      | Liveness probe configuration for Localstack containers                                                                                                                                                                                | Same with [Kubernetes defaults][k8s-probe]  |
+| `readinessProbe`                                     | Readiness probe configuration for Localstack containers                                                                                                                                                                               | Same with [Kubernetes defaults][k8s-probe]  |
+
+[k8s-probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 
 ### RBAC parameters
 

--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the Localstack chart an
 
 ## Change Log
 
+* v0.1.4: Allow customizing livenessProbe/readinessProbe
 * v0.1.3: Allow easy exposure of multiple API services from values config
 
 ## License

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -41,10 +41,12 @@ spec:
               protocol: TCP
             {{- end }}
           livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
             httpGet:
               path: /health
               port: {{ .Values.service.edgeService.name }}
           readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
             httpGet:
               path: /health
               port: {{ .Values.service.edgeService.name }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -50,6 +50,19 @@ debug: false
 ##     value: "serverless,sqs,es"
 extraEnvVars: []
 
+livenessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+readinessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
 service:
   type: NodePort
   edgeService:


### PR DESCRIPTION
In my cluster, the container often gets restarted due to liveness probe timeout.

Added some parameters to customize probes. The default values are same with [Kubernetes defaults](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes).