### PR TITLE
lint chart with kubeval

### DIFF
--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -25,8 +25,7 @@ jobs:
           helm dependency update
           cd -
 
-          helm template $CHARTS > ${TMP}/chart-lint-template-out.yml
-          cat ${TMP}/chart-lint-template-out.yml
+          helm template $CHARTS | tee ${TMP}/chart-lint-template-out.yml
       - name: test
         uses: instrumenta/kubeval-action@master
         with:

--- a/.github/workflows/chart-lint.yaml
+++ b/.github/workflows/chart-lint.yaml
@@ -1,0 +1,33 @@
+name: Test Helm Chart
+
+on: push
+
+jobs:
+  kubeval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+      - name: template
+        run: |
+          CHARTS=charts/localstack
+          TMP=./tmp/templates
+
+          mkdir -p $TMP
+
+          cd $CHARTS
+          helm dependency update
+          cd -
+
+          helm template $CHARTS > ${TMP}/chart-lint-template-out.yml
+          cat ${TMP}/chart-lint-template-out.yml
+      - name: test
+        uses: instrumenta/kubeval-action@master
+        with:
+          files: ./tmp/templates


### PR DESCRIPTION
I was motivated by the comment from @ls-jad-elkik in https://github.com/localstack/helm-charts/pull/16. I was also burnt by that bug, and I am curious what sort of testing could be done on charts. 

There does exist a github action for kubeval, but it didn't seem tailored for helm charts. I found some others online, but I wasn't too confident yet in the support since they seemed a little green. So I handled the templating in a separate step.

Curious on feedback since I am a little new to this space :)

For testing, you can see two runs:
- [fails when I just add the test](https://github.com/nhomble/helm-charts/runs/2214310193?check_suite_focus=true)
- [success when I make the containerPort fix](https://github.com/nhomble/helm-charts/actions/runs/696059084)