### PR TITLE
Add support for binding Docker daemon into Pod

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.1.5
+version: 0.2.0
 name: localstack
 description: A fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -83,8 +83,12 @@ The following table lists the configurable parameters of the Localstack chart an
 | `resources.requests`                                 | The requested resources for Localstack containers                                                                                                                                                                                     | `{}`                                                    |
 | `livenessProbe`                                      | Liveness probe configuration for Localstack containers                                                                                                                                                                                | Same with [Kubernetes defaults][k8s-probe]  |
 | `readinessProbe`                                     | Readiness probe configuration for Localstack containers                                                                                                                                                                               | Same with [Kubernetes defaults][k8s-probe]  |
+| `mountDind.enabled`                                            | Specify the mount of Docker daemon into Pod to enable some AWS services that got runtime dependencies such as Lambdas on GoLang                                                                                                                                                                     | `false`                             |
+| `mountDind.forceTLS`                                            | Specify TLS enforcement on Docker daemon communications                                                                                                                                                                     | `true`                              |
+| `mountDind.image`                                            | Specify DinD image tag                                                                                                                                                                     | `docker:20.10-dind`                            |
 
 [k8s-probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+
 
 ### RBAC parameters
 
@@ -110,6 +114,7 @@ The following table lists the configurable parameters of the Localstack chart an
 
 ## Change Log
 
+* v0.2.0: Add support for Docker-in-Docker functionality
 * v0.1.5: Allow customizing livenessProbe/readinessProbe
 * v0.1.4: Fix a typo that breaks the installation
 * v0.1.3: Allow easy exposure of multiple API services from values config

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
               port: {{ .Values.service.edgeService.name }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if and (.Values.mountDind.enabled) (.Values.mountDind.forceTLS) }}
+          volumeMounts:
+            - name: dind-tls
+              mountPath: /opt/docker/tls
+          {{- end }}
           env:
             - name: DEBUG
               value: {{ ternary "1" "0" .Values.debug | quote }}
@@ -71,9 +76,43 @@ spec:
             - name: SERVICES
               value: {{ .Values.startServices | quote }}
             {{- end }}
+            {{- if .Values.mountDind.enabled }}
+            {{- if .Values.mountDind.forceTLS }}
+            - name: DOCKER_HOST
+              value: tcp://localhost:2376
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            - name: DOCKER_CERT_PATH
+              value: /opt/docker/tls/client
+            {{- else }}
+            - name: DOCKER_HOST
+              value: tcp://localhost:2375
+            {{- end }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+        {{- if .Values.mountDind.enabled }}
+        - name: dind
+          image: {{ .Values.mountDind.image | quote }}
+          securityContext:
+            privileged: true
+          env:
+            {{- if .Values.mountDind.forceTLS }}
+            - name: DOCKER_TLS_CERTDIR
+              value: "/opt/docker/tls"
+            {{- else }}
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+            {{- end }}
+          volumeMounts:
+            - name: dind-storage
+              mountPath: /var/lib/docker
+            {{- if .Values.mountDind.forceTLS }}
+            - name: dind-tls
+              mountPath: /opt/docker/tls
+            {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -86,3 +125,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      volumes:
+      {{- if .Values.mountDind.enabled }}
+      - name: dind-storage
+        emptyDir: {}
+      {{- if .Values.mountDind.forceTLS }}
+      - name: dind-tls
+        emptyDir: {}
+      {{- end }}
+      {{- end }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -41,6 +41,14 @@ debug: false
 # lambdaExecutor: ""
 # dataDir: ""
 
+# This will enable the Docker daemon binding and allow
+# Localstack to provide Lambdas and other AWS services
+# who got container runtime dependencies
+mountDind:
+  enabled: false
+  forceTLS: true
+  image: "docker:20.10-dind"
+
 ## All the parameters from the configuatioan can be added using extraEnvVars.
 ## Ref. https://github.com/localstack/localstack#configurations
 ## extraEnvVars:


### PR DESCRIPTION
We need to run AWS lambdas on Localstack which supports that. However, to be
able to write functions in Golang it requires Docker daemon to be present.

In this commit, we add DinD functionality in Localstack setup to provide
our users with these features.

Signed-off-by: dntosas <ntosas@gmail.com>