### PR TITLE
Support /docker-entrypoint-initaws.d mount point support to run shell scripts

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.2.0
+version: 0.2.1
 name: localstack
 description: A fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the Localstack chart an
 | `lambdaExecutor`                                     | Specify Method to use for executing Lambda functions (partially supported)                                                                                                                                                            | `docker`                                                |
 | `dataDir`                                            | Specify directory for saving persistent data (Not supported yet)                                                                                                                                                                      | `nil` (Localstack Default)                              |
 | `extraEnvVars`                                       | Extra environment variables to be set on Localstack primary containers                                                                                                                                                                | `nil` (Localstack Default)                              |
+| `enableStartupScripts`                               | Mount `/docker-entrypoint-initaws.d` to run startup scripts with `{{ template "localstack.fullname" . }}-init-scripts-config` configMap                                                                                   | `nil` (Localstack Default)                              |
 
 ### Deployment parameters
 

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -92,6 +92,9 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- if .Values.initScriptsVolume.enabled }}
+            - name: {{ template "localstack.fullname" . }}-init-scripts-config
+              mountPath: /docker-entrypoint-initaws.d
         {{- if .Values.mountDind.enabled }}
         - name: dind
           image: {{ .Values.mountDind.image | quote }}
@@ -132,5 +135,10 @@ spec:
       {{- if .Values.mountDind.forceTLS }}
       - name: dind-tls
         emptyDir: {}
+      {{- if .Values.initScriptsVolume.enabled }}
+      - name: {{ template "localstack.fullname" . }}-init-scripts-config
+        configMap:
+          name: {{ template "localstack.fullname" . }}-init-scripts-config
+      {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
             - name: dind-tls
               mountPath: /opt/docker/tls
           {{- end }}
+          {{- if .Values.enableStartupScripts }}
+          volumeMounts:
+            - name: {{ template "localstack.fullname" . }}-init-scripts-config
+              mountPath: /docker-entrypoint-initaws.d
+          {{- end }}
           env:
             - name: DEBUG
               value: {{ ternary "1" "0" .Values.debug | quote }}
@@ -92,9 +97,6 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-            {{- if .Values.initScriptsVolume.enabled }}
-            - name: {{ template "localstack.fullname" . }}-init-scripts-config
-              mountPath: /docker-entrypoint-initaws.d
         {{- if .Values.mountDind.enabled }}
         - name: dind
           image: {{ .Values.mountDind.image | quote }}
@@ -135,10 +137,10 @@ spec:
       {{- if .Values.mountDind.forceTLS }}
       - name: dind-tls
         emptyDir: {}
-      {{- if .Values.initScriptsVolume.enabled }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.enableStartupScripts }}
       - name: {{ template "localstack.fullname" . }}-init-scripts-config
         configMap:
           name: {{ template "localstack.fullname" . }}-init-scripts-config
-      {{- end }}
-      {{- end }}
       {{- end }}


### PR DESCRIPTION
As a developer I want to provide support to create aws resources during localstack startup. We could add the initializer shell scripts to configMap and mount it to  `/docker-entrypoint-initaws.d` so that the particular resource we are looking at is readily available. 