### PR TITLE
Update ingress api version and support helm3

### DIFF
--- a/charts/localstack/.gitignore
+++ b/charts/localstack/.gitignore
@@ -1,2 +1,3 @@
 charts/
 Chart.lock
+values.local.yaml

--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "localstack.fullname" . -}}
 {{- $svcPort := .Values.service.edgeService.targetPort -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $hasAPIv1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- $hasAPIv1Beta := .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- if $hasAPIv1 }}
+apiVersion: networking.k8s.io/v1
+{{- else if $hasAPIv1Beta }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -32,10 +36,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
+          {{- if $hasAPIv1 }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- else -}}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+          {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
`.Capabilities.KubeVersion.GitVersion` has been available since helm v2.15, so this could cause issues for some consumers. Though that version was released in October 2019 and helm 2 has been deprecated since [November 2020](https://helm.sh/blog/helm-v2-deprecation-timeline/), so I think this change is valid. (though that is not up to me in this repo :) )

Resolves [this ticket](https://github.com/localstack/helm-charts/issues/25)

- Added `.values.local.yaml` to `.gitignore` for easier value overrides locally without polluting the codebase
- introduced variables for Ingress API capabilities. These are needed since `networking.k8s.io/v1` has a different path structure and it is not possible to call `.Capabilities.APIVersions.Has "networking.k8s.io/v1"` directly at that point. Trying to do so produces `Error: template: localstack/templates/ingress.yaml:37:30: executing "localstack/templates/ingress.yaml" at <.Capabilities.APIVersions.Has>: can't evaluate field Capabilities in type interface {}`
- left in support for both `networking.k8s.io/v1beta1` and `extensions/v1beta1` API versions