### PR TITLE
Add support for extra annotations and running startup scripts 

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.3.7
+version: 0.4.0
 name: localstack
 description: LocalStack - a fully functional local AWS cloud stack
 type: application
@@ -18,5 +18,5 @@ maintainers:
   email: waldemar.hummer@gmail.com
 dependencies:
   - name: common
-    version: 1.x.x
+    version: 1.11.1
     repository: https://charts.bitnami.com/bitnami

--- a/charts/localstack/templates/_helpers.tpl
+++ b/charts/localstack/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Add extra annotations to every resource
+*/}}
+{{- define "localstack.annotations" -}}
+{{- with .Values.extraAnnotations }}
+{{- range $annotation, $value := index . }}
+{{ $annotation }}: {{ tpl $value $ | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/localstack/templates/configmap.yaml
+++ b/charts/localstack/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.enableStartupScripts -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "localstack.fullname" . }}-init-scripts-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+     {{- include "localstack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "localstack.annotations" . | nindent 4 }}
+data:
+  {{ template "localstack.fullname" . }}-init-scripts-config.sh: |
+    {{- tpl .Values.startupScriptContent $ | nindent 4 }}
+{{- end}}

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "localstack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "localstack.annotations" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}

--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -16,10 +16,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "localstack.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- include "localstack.annotations" . | nindent 4 }}
+    {{- with .Values.ingress.annotations }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/localstack/templates/pvc.yaml
+++ b/charts/localstack/templates/pvc.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "localstack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "localstack.annotations" . | nindent 4 }}
 spec:
   accessModes:
   {{- if not (empty .Values.persistence.accessModes) }}

--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "localstack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "localstack.annotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}

--- a/charts/localstack/templates/serviceaccount.yaml
+++ b/charts/localstack/templates/serviceaccount.yaml
@@ -6,8 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "localstack.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- include "localstack.annotations" . | nindent 4 }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -23,6 +23,9 @@ fullnameOverride: ""
 ##
 extraDeploy: []
 
+## Add additional annotations to every resource
+extraAnnotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -149,3 +152,14 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Mount /docker-entrypoint-initaws.d to run startup scripts with
+# {{ template "localstack.fullname" . }}-init-scripts-config configMap
+enableStartupScripts: false
+
+# Add startup scripts content used by {{ template "localstack.fullname" . }}-init-scripts-config configMap
+# to run at localstack startup
+# startupScriptContent: |
+  # awslocal s3 mb s3://testbucket
+  # awslocal sqs create-queue --queue-name test-queue
+startupScriptContent: ""


### PR DESCRIPTION
* Added extraAnnotations parameter. It will add additional annotations
  to every resource. It's useful when you want to use it with helm
  hooks.
* When enableStartupScripts set to true, it will create configmap {{
  template "localstack.fullname" . }}-init-scripts-config with startup
  script content specified by startupScriptContent parameter and it will
  be executed after localstack startup.
* Added startupScriptContent parameter. It will add startup scripts
  content used by {{ template "localstack.fullname" .
  }}-init-scripts-config configMap to run at localstack startup.