### PR TITLE
feat(cri-registry-auth): add criRegistryAuth to localstack

### DIFF
--- a/charts/localstack/templates/_helpers.tpl
+++ b/charts/localstack/templates/_helpers.tpl
@@ -76,7 +76,7 @@ Add extra annotations to every resource
 Add imagePullSecret
 */}}
 {{- define "imagePullSecret" }}
-{{- with .Values.criAuth.imageCredentials }}
+{{- with .Values.criRegistryAuth.imageCredentials }}
 {{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/localstack/templates/_helpers.tpl
+++ b/charts/localstack/templates/_helpers.tpl
@@ -71,3 +71,12 @@ Add extra annotations to every resource
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Add imagePullSecret
+*/}}
+{{- define "imagePullSecret" }}
+{{- with .Values.criAuth.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/localstack/templates/cri-auth.yaml
+++ b/charts/localstack/templates/cri-auth.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "localstack.name" . }}-cri-auth
+  labels:
+    {{- include "localstack.labels" . | nindent 4 }}
+  annotations:
+    {{- include "localstack.annotations" . | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/charts/localstack/templates/cri-registry-auth.yaml
+++ b/charts/localstack/templates/cri-registry-auth.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.criRegistryAuth.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end}}

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if coalesce (and (.Values.mountDind.enabled) (.Values.mountDind.forceTLS)) .Values.enableStartupScripts .Values.persistence.enabled }}
           volumeMounts:
+            {{- if .Values.mountDind.enabled}}
+              - name: dind-socket
+                mountPath: /var/run/
+            {{- end }}
             {{- if and (.Values.mountDind.enabled) (.Values.mountDind.forceTLS) }}
               - name: dind-tls
                 mountPath: /opt/docker/tls
@@ -72,6 +76,8 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            - name: MAIN_CONTAINER_NAME
+              value: {{ .Chart.Name }}
             - name: DEBUG
               value: {{ ternary "1" "0" .Values.debug | quote }}
             {{- if .Values.kinesisErrorProbability }}
@@ -91,6 +97,8 @@ spec:
               value: {{ .Values.startServices | quote }}
             {{- end }}
             {{- if .Values.mountDind.enabled }}
+            - name: DOCKER_CONFIG
+              value: "/root/.docker"
             {{- if .Values.mountDind.forceTLS }}
             - name: DOCKER_HOST
               value: tcp://localhost:2376
@@ -120,12 +128,18 @@ spec:
               value: ""
             {{- end }}
           volumeMounts:
+            - name: dind-socket
+              mountPath: /var/run/
             - name: dind-storage
               mountPath: /var/lib/docker
             {{- if .Values.mountDind.forceTLS }}
             - name: dind-tls
               mountPath: /opt/docker/tls
             {{- end }}
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "until (docker ps) do sleep 5; done"]
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -145,8 +159,18 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "common.names.fullname" .) }}
       {{- end }}
+      {{- if .Values.criAuth.enabled }}
+      - name: docker-config
+        secret:
+          secretName: {{ include "localstack.name" . }}-cri-auth
+          items:
+          - key: .dockerconfigjson
+            path: config.json
+      {{- end }}
       {{- if .Values.mountDind.enabled }}
       - name: dind-storage
+        emptyDir: {}
+      - name: dind-socket
         emptyDir: {}
       {{- if .Values.mountDind.forceTLS }}
       - name: dind-tls

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "common.names.fullname" .) }}
       {{- end }}
-      {{- if .Values.criAuth.enabled }}
+      {{- if .Values.criRegistryAuth.enabled }}
       - name: docker-config
         secret:
           secretName: {{ include "localstack.name" . }}-cri-auth

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -164,8 +164,8 @@ enableStartupScripts: false
   # awslocal sqs create-queue --queue-name test-queue
 startupScriptContent: ""
 
-criAuth:
-  enable: false
+criRegistryAuth:
+  enabled: false
   imageCredentials:
     registry: quay.io
     username: someone

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -163,3 +163,11 @@ enableStartupScripts: false
   # awslocal s3 mb s3://testbucket
   # awslocal sqs create-queue --queue-name test-queue
 startupScriptContent: ""
+
+criAuth:
+  enable: false
+  imageCredentials:
+    registry: quay.io
+    username: someone
+    password: sillyness
+    email: someone@host.com


### PR DESCRIPTION
First,
I need to execute lambda by private container registry with auth.

criRegistryAuth config can enabled/disabled.

And you need to set your private registry credentials.

Second,
Lambda EXECUTOR with dind need to main container name & docker_host config.