### PR TITLE
Add Custom Annotations Block to Service

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.4.0
+version: 0.4.1
 name: localstack
 description: LocalStack - a fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "localstack.labels" . | nindent 4 }}
   annotations:
     {{- include "localstack.annotations" . | nindent 4 }}
+    {{- with .Values.ingress.annotations }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}

--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "localstack.labels" . | nindent 4 }}
   annotations:
     {{- include "localstack.annotations" . | nindent 4 }}
-    {{- with .Values.ingress.annotations }}
+    {{- with .Values.service.annotations }}
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:


### PR DESCRIPTION
This is a follow up to https://github.com/localstack/helm-charts/pull/48. We are simply adding an annotations block to the service resource as we did in the ingress resource.