### PR TITLE
Removed default ingress annotation

### DIFF
--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -97,9 +97,9 @@ service:
 
 ingress:
   enabled: false
-  annotations:
+  annotations: {}
     # Adjust the ingress class when not using nginx as incress controller
-    kubernetes.io/ingress.class: nginx
+    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local


### PR DESCRIPTION
This PR removes the default nginx annotation from the `values.yaml`

Closes #54 