### PR TITLE
Align startup script changes from version v0.4.0

### DIFF
--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -71,7 +71,11 @@ The following table lists the configurable parameters of the Localstack chart an
 | `startServices`                                      | Specify service names (APIs) to start up                                                                                                                                                                                              | `nil` (Localstack Default)                              |
 | `lambdaExecutor`                                     | Specify Method to use for executing Lambda functions (partially supported)                                                                                                                                                            | `docker`                                                |
 | `extraEnvVars`                                       | Extra environment variables to be set on Localstack primary containers                                                                                                                                                                | `nil` (Localstack Default)                              |
-| `enableStartupScripts`                               | Mount `/docker-entrypoint-initaws.d` to run startup scripts with `{{ template "localstack.fullname" . }}-init-scripts-config` configMap                                                                                               | `nil` (Localstack Default)                              |
+| `enableStartupScripts`                               | Mount `/docker-entrypoint-initaws.d` to run startup scripts with `{{ template "localstack.fullname" . }}-init-scripts-config` configMap                                                                                             | `false`                          
+    |
+| `startupScriptContent`                               | Startup script content when `enableStartupScripts` is `true`                                                                                                              | `nil` (Localstack Default)                              
+    |
+
 
 ### Deployment parameters
 


### PR DESCRIPTION
From version `v0.4.0` on, this chart creates itself a config map `{{ template "localstack.fullname" . }}-init-scripts-config` which previous set ups. The script is now provided via `startupScriptContent`.

This PR documents this `startupScriptContent` field in the README, as it took me some time to understand the changes. Hope it helps others as well.