### PR TITLE
74: Handle persistent store directory change with v1 release

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -71,7 +71,11 @@ spec:
             {{- end }}
             {{- if .Values.persistence.enabled }}
               - name: data
+              {{- if or (eq .Values.image.tag "latest") (not (hasPrefix .Values.image.tag "0.")) }}
+                mountPath: /var/lib/localstack
+              {{- else }}
                 mountPath: /tmp/localstack
+              {{- end }}
             {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Resolves #71 

To resolve the above issue, I could have either:
* Changed `mountPath` to be what is expected by versions of localstack >= 1.0.0
* Or handle backwards compatible versions.

I've decided to implement a backwards compatible fix, however if the maintainers would prefer to only handle the >= 1.0.0 path, I will remove the conditional logic and update the `mountPath` to just be `/var/lib/localstack`

Tested locally by varying the values for `--set image.tag` to `latest`, `1.2.0` and `0.14.5` - the chart deploys successfully with all values.