### PR TITLE
update liveness and readiness probes to use non-deprecated endpoints.

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -50,12 +50,12 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
             httpGet:
-              path: /health
+              path: /_localstack/health
               port: {{ .Values.service.edgeService.name }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
             httpGet:
-              path: /health
+              path: /_localstack/health
               port: {{ .Values.service.edgeService.name }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
updated based on pod logs:
 2022-12-06T03:07:39.056  WARN --- [   asgi_gw_1] localstack.deprecations    : /health is deprecated (since 1.3.0) and will be removed in upcoming releases of LocalStack! Use /_localstack/health instead.