### PR TITLE
Add configuration options for lambda security context

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
             - name: LAMBDA_K8S_LABELS
               value: {{ include "localstack.lambda.labels" . | quote }}
             {{- end }}
+            {{- if .Values.lambda.securityContext }}
+            - name: LAMBDA_K8S_SECURITY_CONTEXT
+              value: {{ toJson .Values.lambda.securityContext | quote }}
+            {{- end }}
             {{- if .Values.lambda.executor }}
             - name: LAMBDA_RUNTIME_EXECUTOR
               value: {{ .Values.lambda.executor | quote }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -182,6 +182,10 @@ lambda:
   #   label1: value1
   #   label2: value2
   #   label3: value3
+  #
+  # Security context to be set on the kubernetes pods spawned by the kubernetes executor.
+  # It will be set on all spawned pods.
+  # Only applicable when executor is set to "kubernetes"
   security_context: {}
   # security_context:
   #   runAsUser: 1000

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -182,6 +182,11 @@ lambda:
   #   label1: value1
   #   label2: value2
   #   label3: value3
+  security_context: {}
+  # security_context:
+  #   runAsUser: 1000
+  #   fsGroup: 1000
+  #   label3: value3
 
 
 nodeSelector: {}


### PR DESCRIPTION
## Problem description
Currently, lambda creates pods which run as root user, without a proper configuration option to adapt it (and other securityContext options).
This option is now there, and the helm chart should provide a representation for this configuration option in the values.yaml file.

## Proposed change
Add an option to set the securityContext of pods spawned by the kubernetes lambda executor in an easy way.