### PR TITLE
fix indentation of volume mounts in deployment

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- with .Values.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 14 }}
             {{- end }}
           {{- end }}
           env:


### PR DESCRIPTION
This PR contains the changes suggested by @corinz in #77.
The indentation level for volumeMounts introduced in #70 was not correct (12 instead of 14):
```
$ cat test-values.yaml
volumeMounts:
  - name: init-scripts
    mountPath: /etc/localstack/init/ready.d
    readOnly: true
persistence:
  enabled: true
$ helm template -f test-values.yaml .
Error: YAML parse error on localstack/templates/deployment.yaml: error converting YAML to JSON: yaml: line 213: did not find expected key

Use --debug flag to render out invalid YAML
```
The issue is resolved by fixing the indentation level as suggested by @corinz.

Fixes #77.