### PR TITLE
Reference to an inexistent page in values.yaml

### DIFF
--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -75,7 +75,7 @@ mountDind:
   image: "docker:20.10-dind"
 
 ## All the parameters from the configuatioan can be added using extraEnvVars.
-## Ref. https://github.com/localstack/localstack#configurations
+## Ref. https://docs.localstack.cloud/references/configuration/
 ## extraEnvVars:
 ##   - name: DEFAULT_REGION
 ##     value: "us-east-1"


### PR DESCRIPTION
`extraEnvVars` docstring leads to the inexistent page documentation page.
This commit replaces the link with the actual documentation.