### PR TITLE
add shebang to avoid exec format error

### DIFF
--- a/charts/localstack/templates/configmap.yaml
+++ b/charts/localstack/templates/configmap.yaml
@@ -10,5 +10,6 @@ metadata:
     {{- include "localstack.annotations" . | nindent 4 }}
 data:
   {{ template "localstack.fullname" . }}-init-scripts-config.sh: |
+    !#/bin/sh
     {{- tpl .Values.startupScriptContent $ | nindent 4 }}
 {{- end}}


### PR DESCRIPTION
The following configuration causes the error:

```2023-06-06T20:03:44.065 ERROR --- [  MainThread] localstack.runtime.init    : Error while running script Script(path='/etc/localstack/init/ready.d/localstack-init-scripts-config.sh', stage=READY, state=ERROR): [Errno 8] Exec format error: '/etc/localstack/init/ready.d/localstack-init-scripts-config.sh'```

```yaml
localstack:
  enabled: true
  fullnameOverride: localstack
  startServices: kinesis
  enableStartupScripts: true
  startupScriptContent: |
    awslocal kinesis create-stream --stream-name bifrost-stream --shard-count 1
```

If we add the shebang, it is no longer malformed:

```yaml
localstack:
  enabled: true
  fullnameOverride: localstack
  startServices: kinesis
  enableStartupScripts: true
  startupScriptContent: |
    #!/bin/sh
    awslocal kinesis create-stream --stream-name bifrost-stream --shard-count 1
```
```2023-06-06T20:10:52.552  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS kinesis.CreateStream => 200```