### PR TITLE
Fix issue where role.create would not toggle creating the Role

### DIFF
--- a/charts/localstack/templates/role.yaml
+++ b/charts/localstack/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.role.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
Based off this portion of the `values.yaml` below for the `role.create` value, it looks like the intent was for the Role to not be created if `role.create` is set to `false`, but currently you would need to also not create the ServiceAccount as well in order to not create the Role. 
```yaml
role:
  # Specifies whether a role & rolebinding with pods / * permissions should be created for the service account
  # Necessary for kubernetes lambda executor
  create: true
```

This would change the Role so it is properly enables creating the role based on the `role.create` value instead of the `serviceAccount.create` value.