### PR TITLE
update bitnami commons version, introduce semver range

### DIFF
--- a/charts/localstack/Chart.lock
+++ b/charts/localstack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.4
-digest: sha256:60ca7a84f0eb714643003820678d06c95d0828f57ab9c602f518e2bdd6d5944e
-generated: "2023-04-27T16:06:05.30378491+02:00"
+  version: 2.9.1
+digest: sha256:d3a1048c4e1ffde6ecfc88656a6168c19515cf15dc043e93b2c334f5df5223d0
+generated: "2023-08-31T09:16:32.3288248+02:00"

--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -19,5 +19,5 @@ maintainers:
   url: https://localstack.cloud/
 dependencies:
   - name: common
-    version: 2.2.4
+    version: ^2.9.0
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
As reported in #92, the chart's dependency on [bitnami's common chart](https://github.com/bitnami/charts/tree/main/bitnami/common) is quite outdated. This can cause issues when this chart is again used as a dependency with other library charts using the commons in a different version, leading to conflicting or at least a non-deterministic selection of transitive dependencies (as outlined in https://github.com/helm/helm/issues/11561).

This PR sets the dependency version to a version range: `^2.9.0`.
We only have to regularly run `helm dependency update` and re-commit the generated lock file to update the chart (within updates in the major version `2`). I might start looking into GitHub actions to automatically update the lock file when new versions of the chart are released.

Thanks @mjasnowski for the great issue report, making us aware of the issue and describing the background. 
Fixes #92 