### PR TITLE
Add envFromSecret to support loading environment variables from a K8S Secret

### DIFF
--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -54,6 +54,14 @@ extraEnvVars:
     value: "<your api key>"
 ```
 
+You can also load the key from a Kubernetes secret:
+```yaml
+envFromSecret:
+- name: LOCALSTACK_API_KEY
+  secret: localstack-secrets
+  key: API_KEY
+```
+
 And you can use these values when installing the chart in your cluster:
 ```bash
 $ helm repo add localstack-charts https://localstack.github.io/helm-charts
@@ -116,6 +124,7 @@ The following table lists the configurable parameters of the Localstack chart an
 | `mountDind.image`                                    | Specify DinD image tag                                                                                                                                                                                                                | `docker:20.10-dind`                                     |
 | `volumes`                                            | Extra volumes to mount                                                                                                                                                                                                                | `[]`                                                    |
 | `volumeMounts`                                       | Extra volumes to mount                                                                                                                                                                                                                | `[]`                                                    |
+| `envFromSecret`                                      |  Specify environment variables from a Kubernetes Secret                                                                                                                                                                                                               | `[]`    
 
 [k8s-probe]: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -120,8 +120,8 @@ spec:
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:
-                name: {{ .secret $ }}
-                key: {{ .key }}
+                  name: {{ .secret }}
+                  key: {{ .key }}
             {{- end }}
             {{- if include "localstack.lambda.labels" . }}
             - name: LAMBDA_K8S_LABELS

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -116,6 +116,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- range .Values.envFromSecret }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                name: {{ .secret $ }}
+                key: {{ .key }}
+            {{- end }}
             {{- if include "localstack.lambda.labels" . }}
             - name: LAMBDA_K8S_LABELS
               value: {{ include "localstack.lambda.labels" . | quote }}


### PR DESCRIPTION
This enables chart users to pull the LOCALSTACK_API_KEY (or some other variable) from a Kubernetes secret, which may be defined in a parent chart or by some other mechanism like IaC.

Refers to feature request #96 