### PR TITLE
Set LOCALSTACK_HOST from service name

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -112,6 +112,13 @@ spec:
             {{- end }}
             - name: LOCALSTACK_K8S_SERVICE_NAME
               value: {{ include "localstack.fullname" . }}
+            {{- if and (or (eq $.Values.service.type "NodePort") (eq $.Values.service.type "LoadBalancer")) (not (empty .Values.service.edgeService.nodePort)) }}
+            - name: LOCALSTACK_HOST
+              value: {{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.nodePort }}
+            {{- else }}
+            - name: LOCALSTACK_HOST
+              value: {{ include "localstack.fullname" . }}
+            {{- end }}
             - name: LOCALSTACK_K8S_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Motivation

LocalStack 3.0.0 standardises `LOCALSTACK_HOST` for services that return URLs. This configuration variable is substituted for domain names if customised. This means for example, that when creating an SQS queue, rather than receiving a queue URL of something like:

```
http://sqs.eu-west-1.localhost.localstack.cloud:4566
```

you receive (with `LOCALSTACK_HOST=foo.bar`):

```
http://sqs.eu-west-1.foo.bar:4566
```

This is important in k8s because the service name is a general DNS entry that resolves to the LocalStack pod. When users of the returned URL try to make calls to that URL, it will now succeed.

# Changes

- set the pod `LOCALSTACK_HOST` environment variable to match the k8s service name
