### PR TITLE
Change API key references to Auth Token

### DIFF
--- a/charts/localstack/README.md
+++ b/charts/localstack/README.md
@@ -42,7 +42,8 @@ The command removes all the Kubernetes components associated with the chart and 
 
 You can use this chart with LocalStack Pro by:
 1. Changing the image to `localstack/localstack-pro`.
-2. Providing your API key as an environment variable.
+2. Providing your Auth Token as an environment variable.
+_(API keys are deprecated by Localstack v3.0)_
 
 You can set these values in a YAML file (in this example `pro-values.yaml`):
 ```yaml
@@ -50,14 +51,14 @@ image:
   repository: localstack/localstack-pro
 
 extraEnvVars:
-  - name: LOCALSTACK_API_KEY
-    value: "<your api key>"
+  - name: LOCALSTACK_AUTH_TOKEN
+    value: "<your auth token>"
 ```
 
-If you have the LocalStack API key in a secret, you can also reference it directly with `extraEnvVars`:
+If you have the LocalStack Auth Token in a secret, you can also reference it directly with `extraEnvVars`:
 ```
 extraEnvVars:
-- name: LOCALSTACK_API_KEY
+- name: LOCALSTACK_AUTH_TOKEN
   valueFrom:
     secretKeyRef:
       name: <name of the secret>

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -26,7 +26,7 @@ mountDind:
 
 # set the API key from an already existing secret
 # extraEnvVars:
-# - name: LOCALSTACK_API_KEY
+# - name: LOCALSTACK_AUTH_TOKEN
 #   valueFrom:
 #     secretKeyRef:
 #       name: <name of the secret containing the API key>
@@ -34,7 +34,7 @@ mountDind:
 
 # or set the API key directly
 # extraEnvVars:
-#   - name: LOCALSTACK_API_KEY
+#   - name: LOCALSTACK_AUTH_TOKEN
 #     value: "<your api key>"
 
 # enable kubernetes lambda executor (only pro)


### PR DESCRIPTION
# Motivation
API keys are deprecated by v3, changed example to the new Auth Token.

#Change
- Update README.md