### PR TITLE
add intial CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# by default, add all repo maintainers as reviewers
+*       @alexrashed @lakkeger


### PR DESCRIPTION
This PR adds an initial CODEOWNERS file.
This file will be picked up by GitHub to automatically assign reviewers to newly PRs based on the changeset.
Initially, this file adds me and @lakkeger (current maintainers) for any changes.