### PR TITLE
add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alexrashed"
+    labels:
+      - "area: dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/chart-lint-test-release.yaml
+++ b/.github/workflows/chart-lint-test-release.yaml
@@ -61,7 +61,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -82,8 +82,7 @@ jobs:
           done
 
       - name: Run chart-releaser
-        # TODO pin version here once https://github.com/helm/chart-releaser-action/pull/134 is released
-        uses: helm/chart-releaser-action@main
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
This PR adds an initial Dependabot config to automatically update GitHub actions in this repo.
In the future (and if helm chart support gets implemented - https://github.com/dependabot/dependabot-core/issues/2237), we might use it for other ecosystems than `github-actions` as well.