### PR TITLE
cleanup command, dnsService, and docs

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if $.Values.command }}
           command:
-            {{ toYaml .Values.command.cmd | nindent 12 }}
+            {{ toYaml .Values.command | nindent 12 }}
           {{- end }}
           ports:
             - name: {{ .Values.service.edgeService.name }}

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -3,9 +3,11 @@
 # enable debugging
 debug: true
 
-
-# enable eager service loading with dynamodb
-startServices: "dynamodb"
+# modify the command to set the ulimit
+command:
+  - /bin/bash
+  - -c
+  - echo 'ulimit -Sn 32767' >> /root/.bashrc && echo 'ulimit -Su 16383' >> /root/.bashrc && docker-entrypoint.sh
 
 
 # enable startup scripts, create a startup script which creates an SQS queue

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -62,6 +62,10 @@ securityContext: {}
 
 debug: false
 
+## @param command Allows you to set an arbitrary command on startup (instead of the default entrypoint script)
+##
+command: []
+
 
 startServices: ""
 # Comma-separated list of AWS CLI service names which should be loaded right when starting LocalStack. If not set, each service is loaded and started on the first request for that service.

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -68,7 +68,7 @@ command: []
 
 
 startServices: ""
-# Comma-separated list of AWS CLI service names which should be loaded right when starting LocalStack. If not set, each service is loaded and started on the first request for that service.
+# Comma-separated list of AWS CLI service names which are the only ones allowed to be used (other services will then by default be prevented from being loaded).
 
 # kinesisErrorProbability: 0.0
 

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -118,7 +118,9 @@ service:
   externalServicePorts:
     start: 4510
     end: 4560
-  #  dnsService: true
+  ## @param service.dnsService Enables or disables the exposure of the LocalStack DNS
+  ##
+  dnsService: false
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Motivation
This PR contains a set of cleanup commits after the recent set of merges.
If the command value has been used (but this one has not yet been released), the usage needs to be adjusted a bit by removing one layer (`cmd`).

## Changes
This PR contains the following changes:
- 30ca70d39304d964ad2a5904b0c483bef9346f09: Changes the `command` value a bit (introduced with https://github.com/localstack/helm-charts/pull/104)
  - Adds an example usage to `test-values.yaml`
  - Adds the value to the `values.yaml`
  - Removes the unnecessary sub-section `cmd`.
- f5255d66f00a31683cd071a0ca9aca985cd90479: Small change to the documentation of `startServices` according to https://github.com/localstack/localstack/pull/9494 (which became the default with v3).
- 47d6971ac3cf3e028e1b0b59d7e377d277fe001c: Cleans up `dnsService` (introduced with https://github.com/localstack/helm-charts/pull/103) in the `values.yaml`

## Notes
After the merge of this PR, we will create a new release which closes #109.