### PR TITLE
add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Motivation
+<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
+
+## Changes
+<!-- What notable changes does this PR make? -->
+
+
+<!-- The following sections are optional, but can be useful!
+## Testing
+Description of how to test the changes
+
+## TODO
+What's left to do:
+- [ ] ...
+- [ ] ...
+-->


### PR DESCRIPTION
## Motivation
I would like to streamline the process when it comes to contributions a bit.
This is why I this PR adds a small template for new PRs.

## Changes
- Adds an initial template which will be used by GitHub for newly created PRs.

## Testing
This approach has been tested (and has proven useful) in other repos (for example in `localstack/localstack` introduced with https://github.com/localstack/localstack-ext/pull/1918).