### PR TITLE
fix link to icon

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
 sources:
 - https://localstack.cloud/
 - https://github.com/localstack/localstack
-icon: https://localstack.cloud/images/localstack.png
+icon: https://cdn.localstack.cloud/images/logos/localstack-logo-icon-color.svg
 maintainers:
 - name: LocalStack Team and Community
   email: info@localstack.cloud


### PR DESCRIPTION
## Motivation
With the latest release, [ArtifactHub](https://artifacthub.io/packages/helm/localstack/localstack) complained that the icon is not reachable anymore. This has been caused by recent changes on the website. This PR fixes the URL such that the link to the icon is working a gain.

## Changes
- Fixes the link to the icon in the `Chart.yaml`