### PR TITLE
Added dnsConfig set to Default

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
       serviceAccountName: {{ include "localstack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -9,6 +9,11 @@ command:
   - -c
   - echo 'ulimit -Sn 32767' >> /root/.bashrc && echo 'ulimit -Su 16383' >> /root/.bashrc && docker-entrypoint.sh
 
+## @param dnsPolicy Allows you to set the Pod dnsPolicy.
+## The default is actually ClusterFirst. Uncomment this to avoid a circular DNS path that will
+## cause the LocalStack instance to crash.
+## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy: "Default"
 
 # enable startup scripts, create a startup script which creates an SQS queue
 enableStartupScripts: true

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -66,6 +66,11 @@ debug: false
 ##
 command: []
 
+## @param dnsPolicy Allows you to set the Pod dnsPolicy.
+## The default is actually ClusterFirst. Uncomment this to avoid a circular DNS path that will
+## cause the LocalStack instance to crash.
+## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+#dnsPolicy: "Default"
 
 startServices: ""
 # Comma-separated list of AWS CLI service names which are the only ones allowed to be used (other services will then by default be prevented from being loaded).

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -70,7 +70,7 @@ command: []
 ## The default is actually ClusterFirst. Uncomment this to avoid a circular DNS path that will
 ## cause the LocalStack instance to crash.
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-#dnsPolicy: "Default"
+# dnsPolicy: "Default"
 
 startServices: ""
 # Comma-separated list of AWS CLI service names which are the only ones allowed to be used (other services will then by default be prevented from being loaded).


### PR DESCRIPTION
The default, if not specified, is ClusterFirst which causes a circular DNS lookup and crashes LocalStack

## Motivation
This is a necessary setting to run LocalStack Pro with DNS configured. If this isn't set, a circular DNS lookup between the ls-dns K8S service and the LocalStack Pod crashes the LocalStack Pod instance.
With this value set to Default, the circular DNS lookup is averted because the Pod inherits the nodes `/etc/resolv.conf` which is set to 127.0.0.1 and doesn't connect to Coredns first.

## Changes
Allows the dnsConfig to be set in values.

## Testing
Changes were tested on EKS Anywhere. 
