### PR TITLE
Add extra rules for role to support ECS

### DIFF
--- a/charts/localstack/templates/role.yaml
+++ b/charts/localstack/templates/role.yaml
@@ -10,7 +10,10 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
   verbs: ["*"]
-{{- if .Values.role.extraRules }}
-{{ toYaml .Values.role.extraRules }}
-{{- end }}
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 {{- end }}

--- a/charts/localstack/templates/role.yaml
+++ b/charts/localstack/templates/role.yaml
@@ -10,4 +10,7 @@ rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods"]
   verbs: ["*"]
+{{- if .Values.role.extraRules }}
+{{ toYaml .Values.role.extraRules }}
+{{- end }}
 {{- end }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -44,6 +44,8 @@ role:
   # The name of the role and rolebinding to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Assign the role extra permissions if required
+  extraRules: []
 
 podLabels: {}
 

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -44,8 +44,6 @@ role:
   # The name of the role and rolebinding to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  # Assign the role extra permissions if required
-  extraRules: []
 
 podLabels: {}
 


### PR DESCRIPTION
## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

When running ECS tasks, the service role needs more permissions than what is specified in the template. Specifically, in addition to the existing rules we need:

```yaml
- apiGroups: [""]
  resources: ["pods/log"]
  verbs: ["get"]
- apiGroups: [""]
  resources: ["services"]
  verbs: ["get", "list"]
```


## Changes
<!-- What notable changes does this PR make? -->

* Add extra role rules to support running ECS tasks

<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
