### PR TITLE
add startupScript checksum to deployment

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -18,9 +18,14 @@ spec:
       {{- include "localstack.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.enableStartupScripts }}
       annotations:
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.enableStartupScripts }}
+        checksum/startup: {{ tpl .Values.startupScriptContent . | sha256sum }}
+      {{- end }}
       {{- end }}
       labels:
         {{- include "localstack.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
## Motivation
Changes in the StartupScripts are not applied to the deployment.

## Changes
Add an annotation with the checksum of the StartupScriptContent to force the refresh of the deployment pod.
