### PR TITLE
Add support for custom priorityClassName

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -14,6 +14,7 @@ command:
 ## cause the LocalStack instance to crash.
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy: "Default"
+priorityClassName: "system-cluster-critical"     # built-in priority class in most k8s distributions
 
 # enable startup scripts, create a startup script which creates an SQS queue
 enableStartupScripts: true

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -247,3 +247,7 @@ volumeMounts: []
 #  - name: <VOLUME_NAME>
 #    mountPath: <CONTAINER_PATH>
 #    readOnly: true
+
+## @param priorityClassName Allows you to set the priorityClassName for the pod
+## The default is not to set any priorityClassName
+# priorityClassName: ""


### PR DESCRIPTION
## Motivation
Added support for custom [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass). For cases when Localstack needs to be prioritized / de-prioritized over other pods


## Changes
Added support for custom priorityClassName


## Testing
Added a test value for common built-in priorityClassName 
