### PR TITLE
Allow setting the ingress class via `spec.ingressClassName`

### DIFF
--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -22,6 +22,10 @@ metadata:
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
+
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -25,7 +25,6 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
 {{- end }}
-
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -130,8 +130,9 @@ service:
 ingress:
   enabled: false
   annotations: {}
-  # To set the ingress class via spec.ingressClassName, uncomment the line below
-  # ingressClassName: nginx
+  ## @param ingress.ingressClassName Set the name of the class to use
+  ##
+  ingressClassName: ""
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -130,9 +130,18 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # Adjust the ingress class when not using nginx as incress controller
+    # Adjust the ingress class when not using nginx as ingress controller
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+
+    # If you are using SSL passthrough for the certificates for nginx, uncomment the
+    # annotations below (note: nginx needs to be started with `--enable-ssl-passthrough` for these to work)
+    # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+  # To set the ingress class via spec.ingressClassName, uncomment the line below
+  # ingressClassName: nginx
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -130,16 +130,6 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # Adjust the ingress class when not using nginx as ingress controller
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-
-    # If you are using SSL passthrough for the certificates for nginx, uncomment the
-    # annotations below (note: nginx needs to be started with `--enable-ssl-passthrough` for these to work)
-    # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
-
   # To set the ingress class via spec.ingressClassName, uncomment the line below
   # ingressClassName: nginx
   hosts:


### PR DESCRIPTION
Fixes: https://github.com/localstack/helm-charts/issues/114

The annotation `kubernetes.io/ingress.class` is deprecated and shouldn't be used for specifying the ingress class.

Instead the option `ingressClassName` should be used. This introduces that as an option to values and adds additional annotation comments for enabling SSL passthrough when nginx is used as an ingress controller

As a result of this change, in local testing the following side effects were observed:

## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

## Changes
<!-- What notable changes does this PR make? -->


<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
