### PR TITLE
add support to ingressClassName field

### DIFF
--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -22,6 +22,9 @@ metadata:
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -129,6 +129,7 @@ service:
 
 ingress:
   enabled: false
+  ingressClassName: ""
   annotations: {}
     # Adjust the ingress class when not using nginx as incress controller
     # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
add support for ingressClassName field

## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
The annotation "kubernetes.io/ingress.class" is deprecated and the ingressClassName field on Ingresses is a replacement for that.

## Changes
<!-- What notable changes does this PR make? -->
Enable support for ingressClassName field which is a replacement of the deprecated annotation "kubernetes.io/ingress.class"

<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
