### PR TITLE
Support templates in ingress host

### DIFF
--- a/charts/localstack/templates/NOTES.txt
+++ b/charts/localstack/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ (tpl $host.host $) }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -26,17 +26,15 @@ spec:
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
-      {{- $base := . }}
       {{- range .hosts }}
-        - {{ tpl . $base | quote }}
+        - {{ tpl . $ | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
-  {{- $base := . }}
   {{- range .Values.ingress.hosts }}
-    - host: {{ tpl .host $base | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/localstack/templates/ingress.yaml
+++ b/charts/localstack/templates/ingress.yaml
@@ -26,15 +26,17 @@ spec:
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
+      {{- $base := . }}
       {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $base | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
+  {{- $base := . }}
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $base | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -20,6 +20,12 @@ mountDind:
   forceTLS: true
 
 
+ingressHost: chart-example.local
+ingress:
+  enabled: true
+  hosts:
+    - host: {{ .Values.ingressHost }}
+
 # enable localstack pro (don't forget to set your API key)
 # image:
 #   repository: localstack/localstack-pro

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -24,7 +24,7 @@ ingressHost: chart-example.local
 ingress:
   enabled: true
   hosts:
-    - host: {{ .Values.ingressHost }}
+    - host: "{{ .Values.ingressHost }}"
 
 # enable localstack pro (don't forget to set your API key)
 # image:

--- a/charts/localstack/test-values.yaml
+++ b/charts/localstack/test-values.yaml
@@ -25,6 +25,9 @@ ingress:
   enabled: true
   hosts:
     - host: "{{ .Values.ingressHost }}"
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
 
 # enable localstack pro (don't forget to set your API key)
 # image:


### PR DESCRIPTION
## Motivation
Added support for templates in ingress host field.

## Changes
Run the hosts through `tpl` function. I had to save the `base` template in a var, to use it inside the `range` loop



## Testing
Added test values 
