### PR TITLE
Add pods/exec permissions to the service account role

### DIFF
--- a/charts/localstack/templates/role.yaml
+++ b/charts/localstack/templates/role.yaml
@@ -14,6 +14,9 @@ rules:
   resources: ["pods/log"]
   verbs: ["get"]
 - apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
   resources: ["services"]
   verbs: ["get", "list"]
 {{- end }}

--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -47,11 +47,10 @@ spec:
       containerPort: 53
       protocol: UDP
     {{- end }}
-      {{- range $index, $port := untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}
-    - name: "external-service-port-{{ $port }}"
-      port: {{ $port }}
-      targetPort: "ext-svc-{{ $port }}"
-      nodePort: {{ add $index 31510 }}
+    {{- range untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}
+    - name: "external-service-port-{{ . }}"
+      port: {{ . }}
+      targetPort: "ext-svc-{{ . }}"
     {{- end }}
   selector:
     {{- include "localstack.selectorLabels" . | nindent 4 }}

--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -47,10 +47,11 @@ spec:
       containerPort: 53
       protocol: UDP
     {{- end }}
-    {{- range untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}
-    - name: "external-service-port-{{ . }}"
-      port: {{ . }}
-      targetPort: "ext-svc-{{ . }}"
+      {{- range $index, $port := untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}
+    - name: "external-service-port-{{ $port }}"
+      port: {{ $port }}
+      targetPort: "ext-svc-{{ $port }}"
+      nodePort: {{ add $index 31510 }}
     {{- end }}
   selector:
     {{- include "localstack.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
With the effort to improve kubernetes support, we try to use kubernetes pods to run database containers.

However, our implementations of these databases requires to `exec` into the pod / container.

## Changes
<!-- What notable changes does this PR make? -->
* Add permission to `exec` in a pod to the service account role

<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
