### PR TITLE
Add option to define a pre-known nodeport range for service ports

### DIFF
--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -47,10 +47,13 @@ spec:
       containerPort: 53
       protocol: UDP
     {{- end }}
-    {{- range untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}
-    - name: "external-service-port-{{ . }}"
-      port: {{ . }}
-      targetPort: "ext-svc-{{ . }}"
+    {{- range $index, $port := untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}
+    - name: "external-service-port-{{ $port }}"
+      port: {{ $port }}
+      targetPort: "ext-svc-{{ $port }}"
+    {{- with $.Values.service.externalServicePorts.nodePortStart|int }}
+      nodePort: {{ add $index . }}
+    {{- end }}
     {{- end }}
   selector:
     {{- include "localstack.selectorLabels" . | nindent 4 }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -123,7 +123,7 @@ service:
   externalServicePorts:
     start: 4510
     end: 4560
-    ## @param service.externalServicePorts.nodeStart specifies the starting node ports the serviceports are mapped to
+    ## @param service.externalServicePorts.nodePortStart specifies the starting node ports the serviceports are mapped to
     ##   has to be in the node port range configured. See https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     # nodePortStart: 31510
   ## @param service.dnsService Enables or disables the exposure of the LocalStack DNS

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -123,6 +123,9 @@ service:
   externalServicePorts:
     start: 4510
     end: 4560
+    ## @param service.externalServicePorts.nodeStart specifies the starting node ports the serviceports are mapped to
+    ##   has to be in the node port range configured. See https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    # nodePortStart: 31510
   ## @param service.dnsService Enables or disables the exposure of the LocalStack DNS
   ##
   dnsService: false


### PR DESCRIPTION
## Motivation

Currently, we have no option to predefine or predict the node port values for service ports within the helm chart, they are randomly assigned.
However, if you need to access a service port from outside the cluster, you need to know the port mapping between the node port and the service port, which is currently only queryable through the k8s API.

To make this easier, I introduced an option to predefine a node port start range for node ports.

For example, if the service port range starts at `4510`, and the node port range starts at `31510`, the port mappings would look like this:

```yaml
    - name: "external-service-port-4510"
      port: 4510
      targetPort: "ext-svc-4510"
      nodePort: 31510
    - name: "external-service-port-4511"
      port: 4511
      targetPort: "ext-svc-4511"
      nodePort: 31511
```

If the new variable `service.externalServicePorts.nodePortStart` is not set, the helm chart will assign random ports just like it does currently:

```yaml
    - name: "external-service-port-4510"
      port: 4510
      targetPort: "ext-svc-4510"
    - name: "external-service-port-4511"
      port: 4511
```

This variable is not set by default, so the default behavior does not change.

## Changes
* Add option to define a `nodePortStart` to make node port ranges predictable when starting LocalStack using the helm chart
