### PR TITLE
Add support for providing env vars with envFrom

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.6.15
+version: 0.6.16
 name: localstack
 description: LocalStack - a fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -188,6 +188,10 @@ spec:
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
         {{- if .Values.mountDind.enabled }}
         - name: dind
           image: {{ .Values.mountDind.image | quote }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -97,6 +97,11 @@ mountDind:
 ##     value: "serverless,sqs,es"
 extraEnvVars: []
 
+## envFrom Allows you to set additional environment variables from a ConfigMap or Secret
+## - configMapRef:
+##     name: configmap-name
+envFrom: []
+
 livenessProbe:
   initialDelaySeconds: 0
   periodSeconds: 10


### PR DESCRIPTION
## Motivation

We include the localstack helm chart as a dependency to a wrapper chart and would like to be able to set an environment variable that is derived from a value passed to the wrapper. This is currently not possible as the values for the localstack subchart can not refer to another value. Here's a brief example of how we'd like to use this:

Chart.yaml:
```yaml
apiVersion: v2
name: wrapper-chart
description: A wrapper around the localstack chart
type: application
version: 1.0.0
appVersion: "1.0.0"
dependencies:
  - name: localstack
    version: 0.6.16
    repository: https://localstack.github.io/helm-charts
```

Wrapper chart values.yaml
```yaml
subdomain: foobar
environment: example

localstack:
  extraEnvVars:
    - name: SERVICES
      value: s3
  envFrom:
    - configMapRef:
        name: localstack-env-vars
```

localstack-env-vars-configmap.yaml
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: localstack-env-vars
data:
  LOCALSTACK_HOST: "{{ .Values.subdomain }}.{{ .Values.environment }}.internal"
```

## Changes

The PR adds support for providing environment variables via ConfigMaps and/or Secrets via envFrom.
