### PR TITLE
Support exposing DNS UDP for service

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -66,8 +66,12 @@ spec:
               protocol: TCP
             {{- end }}
             {{- if .Values.service.dnsService }}
-            - name: dns-svc
+            - name: dns-svc-tcp
               containerPort: 53
+              protocol: TCP
+            - name: dns-svc-udp
+              containerPort: 53
+              protocol: UDP
             {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}


### PR DESCRIPTION
## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

Currently enabling `dnsService: true` only exposes the DNS port to the service _with the TCP protocol_, whereas both TCP and UDP should be exposed. DNS was originally a UDP-based protocol.

## Changes
<!-- What notable changes does this PR make? -->

Expose both TCP and UDP ports in the LocalStack deployment, if `dnsService: true`.


## Testing


* Deploy LocalStack into a cluster with `dnsService: true` from the `main` branch
* Run `kubectl run -i --tty --rm debug --image ghcr.io/simonrw/docker-debug:main --restart=Never -- dig @<localstack service ip address> example.com`
  * this uses a Docker image [built by me](https://github.com/simonrw/docker-debug) which contains the `dig` tool
* The request should time out
* Check out this branch
* Repeat the test
* The response should contain the IP address of `example.com`