### PR TITLE
Update some sensible defaults and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following command allows you to download and install all the charts from thi
 $ helm repo add localstack https://localstack.github.io/helm-charts
 ```
 
-### Using Helm
+## Using Helm
 
 Once you have installed the Helm client, you can deploy a Helm chart into a Kubernetes cluster.
 
@@ -81,6 +81,24 @@ Useful Helm Client Commands:
 * View available charts: `helm search repo`
 * Install a chart: `helm install <name> localstack/<chart>`
 * Upgrade your application: `helm upgrade`
+
+### Customization
+
+The helm chart can be customized with [Helm override files](https://helm.sh/docs/helm/helm_upgrade/) (the `-f/--values`) flag.
+A yaml file can be provided to override the default settings in the [default values.yml](https://github.com/localstack/helm-charts/blob/main/charts/localstack/values.yaml).
+
+A common customisation is to specify the LocalStack pod resource requests and limits. In particular, AWS EKS on Fargate commonly terminates LocalStack pods with the default resource requests. Consider adding the following section to your customization file:
+
+```yaml
+resources:
+  requests:
+    cpu: 1
+    memory: 1Gi
+  limits:
+    cpu: 2
+    memory: 2Gi
+```
+
 
 ### Using the chart in OpenShift
 

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -106,17 +106,17 @@ extraEnvVars: []
 envFrom: []
 
 livenessProbe:
-  initialDelaySeconds: 0
+  initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 1
   successThreshold: 1
-  failureThreshold: 3
+  failureThreshold: 5
 readinessProbe:
-  initialDelaySeconds: 0
+  initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 1
   successThreshold: 1
-  failureThreshold: 3
+  failureThreshold: 5
 
 service:
   type: NodePort


### PR DESCRIPTION

## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

When running LocalStack on EKS on Fargate, the LocalStack pod often gets terminated. This is for two reasons:
* the health probes are too restrictive, and
* the default pod requests cause pods to be terminated too quickly


## Changes
<!-- What notable changes does this PR make? -->


A consideration was made for both local and EKS/Fargate scenarios, so defaults were not updated to handle one scenario at the cost of the other.

- Increase default probe delay and failure thresholds
    - these do make local development a little slower, but in my experience, LocalStack does not take much less than 10 seconds to become ready anyway
- Add section to the docs on helm customzation
    - the defaults were _not_ updated because this may cause resource exhaustion for local development which would not be a good user experience 


<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
