### PR TITLE
Several fixes in the template, expose pod IP in environment to LocalStack

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -139,6 +139,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: LOCALSTACK_K8S_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             {{- if include "localstack.lambda.labels" . }}
             - name: LAMBDA_K8S_LABELS
               value: {{ include "localstack.lambda.labels" . | quote }}

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -139,7 +139,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: LOCALSTACK_K8S_IP
+            - name: LOCALSTACK_K8S_POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP

--- a/charts/localstack/templates/role.yaml
+++ b/charts/localstack/templates/role.yaml
@@ -19,6 +19,9 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["*"]
 {{- if .Values.role.extraRoles }}
 {{ include "common.tplvalues.render" (dict "value" .Values.role.extraRoles "context" $) }}
 {{- end }}

--- a/charts/localstack/templates/service.yaml
+++ b/charts/localstack/templates/service.yaml
@@ -40,11 +40,11 @@ spec:
     {{- if .Values.service.dnsService }}
     - name: dns-tcp
       port: 53
-      containerPort: 53
+      targetPort: 53
       protocol: TCP
     - name: dns-udp
       port: 53
-      containerPort: 53
+      targetPort: 53
       protocol: UDP
     {{- end }}
     {{- range $index, $port := untilStep (.Values.service.externalServicePorts.start|int) (.Values.service.externalServicePorts.end|int) 1 }}


### PR DESCRIPTION
## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
While improving our test pipeline for k8s, I have noticed some minor issues with our helm chart.

Also, I have noticed the advantages of having the pod IP address injected per environment variable. This saves us from inspecting the network interfaces with `ip` if we need it. (Current plan is to potentially fall back for it for DNS integrations, if `values.service.dnsService` is set to `false`).

We need the additional permissions for the service account role for EC2 on k8s.

## Changes
<!-- What notable changes does this PR make? -->
* Fix `containerPort` in service definitions if `values.service.dnsService=true` - this is not a valid key, it should be `targetPort`. Since it is the same port as the service exposes, it still behaves correct (as k8s falls back to the service port without a `targetPort`), but produces a warning like this:
```
W0210 14:43:50.658526    7718 warnings.go:70] unknown field "spec.ports[1].containerPort"
W0210 14:43:50.658919    7718 warnings.go:70] unknown field "spec.ports[2].containerPort"
```
* Introduce `LOCALSTACK_K8S_POD_IP` with the pod IP
* Add extra permissions to allow EC2 on k8s to create deployments

/cc @RobertLucian 
<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
