### PR TITLE
Add missing env var for helm chart deployment

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -115,6 +115,8 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            - name: CONTAINER_RUNTIME
+              value: kubernetes
             - name: DEBUG
               value: {{ ternary "1" "0" .Values.debug | quote }}
             {{- if .Values.service.externalServicePorts.start }}


### PR DESCRIPTION
## Motivation

This is needed in order to get the KubernetesContainer class to come into effect (instead of the DockerContainer class). Exactly the same as with the K8s operator.

