### PR TITLE
feat(charts): provide more control over helm tests

### DIFF
--- a/charts/localstack/templates/tests/test-connection.yaml
+++ b/charts/localstack/templates/tests/test-connection.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tests.connection.enabled }}
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -14,16 +14,25 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
-    - name: {{ .Values.tests.connection.name }}
-      image: {{ .Values.tests.connection.image }}
-      {{- with .Values.tests.connection.command }}
+    - name: curl-edge
+      image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
       command:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      args:
-        {{- $global := . }}
-        {{- range $arg := index .Values.tests.connection.args }}
-        - {{ tpl $arg $global | quote }}
-        {{- end }}
+        - /bin/bash
+        - -c
+        - |
+          URL='{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}/_localstack/health'
+          RETRIES=5
+          DELAY=2
+          for i in $(seq 1 $RETRIES); do
+            if curl -vvv "$URL"; then
+              echo "Connection successful!"
+              exit 0
+            else
+              echo "Retry $i of $RETRIES..."
+              sleep $DELAY
+            fi
+          done
+          echo "Failed to connect after $RETRIES attempts."
+          exit 1
   restartPolicy: Never
 {{- end }}

--- a/charts/localstack/templates/tests/test-connection.yaml
+++ b/charts/localstack/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.connection.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,8 +14,16 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
-    - name: wget-edge
-      image: busybox
-      command: ['wget']
-      args: ['-q', '--server-response', '--output-document', '-', '{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}/_localstack/health']
+    - name: {{ .Values.tests.connection.name }}
+      image: {{ .Values.tests.connection.image }}
+      {{- with .Values.tests.connection.command }}
+      command:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      args:
+        {{- $global := . }}
+        {{- range $arg := index .Values.tests.connection.args }}
+        - {{ tpl $arg $global | quote }}
+        {{- end }}
   restartPolicy: Never
+{{- end }}

--- a/charts/localstack/templates/tests/test-s3.yaml
+++ b/charts/localstack/templates/tests/test-s3.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tests.s3.enabled }}
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -14,17 +14,27 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
-    - name: {{ .Values.tests.s3.name }}
-      image: {{ .Values.tests.s3.image }}
-      {{- with .Values.tests.s3.command }}
+    - name: awscli-s3
+      image: {{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}
       command:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      args:
-        {{- $global := . }}
-        {{- range $arg := index .Values.tests.s3.args }}
-        - {{ tpl $arg $global | quote }}
-        {{- end }}
+        - /bin/bash
+        - -c
+        - |
+          RETRIES=5
+          DELAY=2
+          URL=http://{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}
+          COMMAND="aws --debug --endpoint-url $URL s3 ls"
+          for i in $(seq 1 $RETRIES); do
+            if $COMMAND; then
+              echo "aws-cli s3 ls successful!"
+              exit 0
+            else
+              echo "Retry $i of $RETRIES..."
+              sleep $DELAY
+            fi
+          done
+          echo "Failed to aws-cli s3 ls after $RETRIES attempts."
+          exit 1
       env:
       - name: AWS_ACCESS_KEY_ID
         value: test

--- a/charts/localstack/templates/tests/test-s3.yaml
+++ b/charts/localstack/templates/tests/test-s3.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.s3.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,9 +14,17 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   containers:
-    - name: awscli-s3
-      image: amazon/aws-cli
-      args: ['--debug', '--endpoint-url', 'http://{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}', 's3', 'ls']
+    - name: {{ .Values.tests.s3.name }}
+      image: {{ .Values.tests.s3.image }}
+      {{- with .Values.tests.s3.command }}
+      command:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      args:
+        {{- $global := . }}
+        {{- range $arg := index .Values.tests.s3.args }}
+        - {{ tpl $arg $global | quote }}
+        {{- end }}
       env:
       - name: AWS_ACCESS_KEY_ID
         value: test
@@ -24,3 +33,4 @@ spec:
       - name: AWS_DEFAULT_REGION
         value: us-east-1
   restartPolicy: Never
+{{- end }}

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -257,33 +257,17 @@ volumes: []
 #      path: <HOST_PATH>
 #    name: <VOLUME_NAME>
 
-# Customize and enable/disable helm tests, if necessary
-#
-# args are run through the tpl function, so on render it will interpolate
-# strings as templates within the tests templates.
+# Helm test controls
 tests:
-  connection:
-    enabled: true
-    name: wget-edge
-    image: busybox:latest
-    command:
-      - wget
-    args:
-      - -q
-      - --server-response
-      - --output-document
-      - '-'
-      - '{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}/_localstack/health'
-  s3:
-    enabled: true
-    name: awscli-s3
-    image: amazon/aws-cli
-    args:
-      - --debug
-      - --endpoint-url
-      - 'http://{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}'
-      - s3
-      - ls
+  # An option to enable/disable helm tests from values (useful if subcharting localstack
+  # as other chart tests may make this test redundant)
+  enabled: true
+
+  # Amazon's aws-cli image is used for all tests. Update this if specific repository
+  # or tag is needed for an environment
+  image:
+    repository: amazon/aws-cli
+    tag: latest
 
 # @param volumeMounts Extra volumes to mount
 volumeMounts: []

--- a/charts/localstack/values.yaml
+++ b/charts/localstack/values.yaml
@@ -257,6 +257,34 @@ volumes: []
 #      path: <HOST_PATH>
 #    name: <VOLUME_NAME>
 
+# Customize and enable/disable helm tests, if necessary
+#
+# args are run through the tpl function, so on render it will interpolate
+# strings as templates within the tests templates.
+tests:
+  connection:
+    enabled: true
+    name: wget-edge
+    image: busybox:latest
+    command:
+      - wget
+    args:
+      - -q
+      - --server-response
+      - --output-document
+      - '-'
+      - '{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}/_localstack/health'
+  s3:
+    enabled: true
+    name: awscli-s3
+    image: amazon/aws-cli
+    args:
+      - --debug
+      - --endpoint-url
+      - 'http://{{ include "localstack.fullname" . }}:{{ .Values.service.edgeService.targetPort }}'
+      - s3
+      - ls
+
 # @param volumeMounts Extra volumes to mount
 volumeMounts: []
 #  - name: <VOLUME_NAME>


### PR DESCRIPTION
## Motivation

There are times when we need a bit more control over the `Pod` that's run in `helm test`. For example:

- Update the image to use a different repository (like a pull-thru cache)
- Disable a test entirely due to a finicky CI or local network
- Should a future test image have a breaking change, we can update args/commands via values as a quick workaround rather than waiting for a new helm release

## Changes

This change pulls the defaults into the `values.yaml` for that control.

Optionally, we can enable/disable any of the tests.

## Testing

Ran `helm template test .` before and after the change and confirmed the rendered templates are the same except for:

- adding an explicit `latest` tag for the busybox image
- formatting of command/args list

```diff
--- /tmp/localstack-orig.yaml	2025-03-07 09:35:10
+++ /tmp/localstack-new.yaml	2025-03-07 09:34:16
@@ -494,9 +494,15 @@
 spec:
   containers:
     - name: wget-edge
-      image: busybox
-      command: ['wget']
-      args: ['-q', '--server-response', '--output-document', '-', 'test-localstack:4566/_localstack/health']
+      image: busybox:latest
+      command:
+        - wget
+      args:
+        - "-q"
+        - "--server-response"
+        - "--output-document"
+        - "-"
+        - "test-localstack:4566/_localstack/health"
   restartPolicy: Never
 ---
 # Source: localstack/templates/tests/test-s3.yaml
@@ -517,7 +523,12 @@
   containers:
     - name: awscli-s3
       image: amazon/aws-cli
-      args: ['--debug', '--endpoint-url', 'http://test-localstack:4566', 's3', 'ls']
+      args:
+        - "--debug"
+        - "--endpoint-url"
+        - "http://test-localstack:4566"
+        - "s3"
+        - "ls"
       env:
       - name: AWS_ACCESS_KEY_ID
         value: test
```
