### PR TITLE
Add environment variables for LS pod name and uid

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -143,6 +143,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: LOCALSTACK_K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: LOCALSTACK_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if include "localstack.lambda.labels" . }}
             - name: LAMBDA_K8S_LABELS
               value: {{ include "localstack.lambda.labels" . | quote }}


### PR DESCRIPTION
## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
With upcoming changes, we want to create owner relationships (https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/) between the LS pod and the pods it spawns.

This should avoid leftover pods after the LS pod is deleted.

## Changes
<!-- What notable changes does this PR make? -->
* Introduce a `LOCALSTACK_K8S_POD_UID` environment variable containing the pod UID.
* Introduce a `LOCALSTACK_K8S_POD_NAME` environment variable containing the pod name.


<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
