### PR TITLE
Add version for analytics

### DIFF
--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -188,8 +188,12 @@ spec:
             {{- end }}
             - name: OVERRIDE_IN_DOCKER
               value: "1"
-            - name: LOCALSTACK_HELM_CHART_VERSION
-              value: "{{ .Chart.Version }}"
+            - name: LOCALSTACK_K8S_DEPLOYMENT_METHOD
+              value: "helm/{{ .Chart.Version }}"
+            {{- if not .Values.mountDind.enabled }}
+            - name: CONTAINER_RUNTIME
+              value: kubernetes
+            {{- end }}
             {{- if .Values.mountDind.enabled }}
             {{- if .Values.mountDind.forceTLS }}
             - name: DOCKER_HOST

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -190,10 +190,6 @@ spec:
               value: "1"
             - name: LOCALSTACK_K8S_DEPLOYMENT_METHOD
               value: "helm/{{ .Chart.Version }}"
-            {{- if not .Values.mountDind.enabled }}
-            - name: CONTAINER_RUNTIME
-              value: kubernetes
-            {{- end }}
             {{- if .Values.mountDind.enabled }}
             {{- if .Values.mountDind.forceTLS }}
             - name: DOCKER_HOST

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -188,6 +188,8 @@ spec:
             {{- end }}
             - name: OVERRIDE_IN_DOCKER
               value: "1"
+            - name: LOCALSTACK_HELM_CHART_VERSION
+              value: "{{ .Chart.Version }}"
             {{- if .Values.mountDind.enabled }}
             {{- if .Values.mountDind.forceTLS }}
             - name: DOCKER_HOST


### PR DESCRIPTION
## Motivation
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->

In order to properly capture analytics, we are adding to helm chart and the executor a  `LOCALSTACK_K8S_DEPLOYMENT_METHOD` that will allow us to track the method used by the user to deploy LocalStack in K8s

## Changes
<!-- What notable changes does this PR make? -->

- adds `LOCALSTACK_K8S_DEPLOYMENT_METHOD=helm/<version>`
- adds `CONTAINER_RUNTIME=kubernetes` when `dind` is not enabled

<!-- The following sections are optional, but can be useful!
## Testing
Description of how to test the changes

## TODO
What's left to do:
- [ ] ...
- [ ] ...
-->
