### PR TITLE
Support cloud-agnostic K8s config variable names

### DIFF
--- a/charts/localstack/Chart.yaml
+++ b/charts/localstack/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 appVersion: latest
-version: 0.7.0
+version: 0.7.1
 name: localstack
 description: LocalStack - a fully functional local AWS cloud stack
 type: application

--- a/charts/localstack/templates/_helpers.tpl
+++ b/charts/localstack/templates/_helpers.tpl
@@ -87,6 +87,34 @@ Create the RoleBinding name for the service account
 {{- end }}
 {{- end }}
 
+{{/*
+Determine whether to use the new cloud-agnostic Kubernetes runtime config
+variable names (K8S_*) introduced in LocalStack 2026.07.
+
+LocalStack uses CalVer image tags (e.g. 2026.06.0). Versions up to and
+including 2026.06 only understand the legacy names (LOCALSTACK_K8S_*,
+LAMBDA_K8S_*); 2026.07 and later renamed them. The old names still work as
+deprecated fallbacks on newer versions, so we only emit the new names when
+we are confident the version is > 2026.06.
+
+Rolling/non-CalVer tags (latest, stable, dev, a bare year, ...) are treated
+as the newest version, consistent with the rest of this chart. Returns a
+non-empty string when the new names should be used, empty otherwise.
+*/}}
+{{- define "localstack.useNewK8sVars" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
+{{- $calver := $tag | regexFind "^[0-9]+\\.[0-9]+" -}}
+{{- $useNew := true -}}
+{{- if $calver -}}
+{{- $parts := splitList "." $calver -}}
+{{- $ym := add (mul (index $parts 0 | int) 100) (index $parts 1 | int) -}}
+{{- if le $ym 202606 -}}
+{{- $useNew = false -}}
+{{- end -}}
+{{- end -}}
+{{- if $useNew -}}true{{- end -}}
+{{- end -}}
+
 {{- define "localstack.lambda.prepare_labels" -}}
 {{- if .Values.lambda.labels }}
 {{- range $key, $value := .Values.lambda.labels -}}

--- a/charts/localstack/templates/deployment.yaml
+++ b/charts/localstack/templates/deployment.yaml
@@ -114,6 +114,7 @@ spec:
             {{- toYaml . | nindent 14 }}
             {{- end }}
           {{- end }}
+          {{- $useNewK8sVars := include "localstack.useNewK8sVars" . }}
           env:
             - name: DEBUG
               value: {{ ternary "1" "0" .Values.debug | quote }}
@@ -135,7 +136,7 @@ spec:
             {{- end }}
             - name: LOCALSTACK_K8S_SERVICE_NAME
               value: {{ include "localstack.fullname" . }}
-            - name: LOCALSTACK_K8S_NAMESPACE
+            - name: {{ if $useNewK8sVars }}K8S_NAMESPACE{{ else }}LOCALSTACK_K8S_NAMESPACE{{ end }}
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -152,11 +153,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             {{- if include "localstack.lambda.labels" . }}
-            - name: LAMBDA_K8S_LABELS
+            - name: {{ if $useNewK8sVars }}K8S_LABELS{{ else }}LAMBDA_K8S_LABELS{{ end }}
               value: {{ include "localstack.lambda.labels" . | quote }}
             {{- end }}
             {{- if .Values.lambda.securityContext }}
-            - name: LAMBDA_K8S_SECURITY_CONTEXT
+            - name: {{ if $useNewK8sVars }}K8S_CONTAINER_SECURITY_CONTEXT{{ else }}LAMBDA_K8S_SECURITY_CONTEXT{{ end }}
               value: {{ toJson .Values.lambda.securityContext | quote }}
             {{- end }}
             {{- if .Values.lambda.executor }}


### PR DESCRIPTION
## Motivation

An upcoming LocalStack release renames the Kubernetes runtime configuration variables to cloud-agnostic names, effective from the **2026.07** release. The old names continue to work as deprecated fallbacks on newer versions, but the new names do **not** exist on older versions — so the chart must choose names based on the image version.

LocalStack now uses CalVer image tags (`2026.06.0`, `2026.05.4`, …), so "higher than 2026.06" maps directly onto the tag's `YYYY.MM`.

## Changes

- **`_helpers.tpl`**: new `localstack.useNewK8sVars` helper that parses the image tag's leading `year.month` and returns truthy only when it is `> 2026.06`. Rolling / non-CalVer tags (`latest`, `stable`, `dev`, bare year) are treated as newest → new names, consistent with the chart's existing convention for unknown tags.
- **`deployment.yaml`**: the three affected env vars now switch names based on version:

  | Legacy (≤ 2026.06) | New (> 2026.06) |
  | --- | --- |
  | `LOCALSTACK_K8S_NAMESPACE` | `K8S_NAMESPACE` |
  | `LAMBDA_K8S_LABELS` | `K8S_LABELS` |
  | `LAMBDA_K8S_SECURITY_CONTEXT` | `K8S_CONTAINER_SECURITY_CONTEXT` |

  The other `LOCALSTACK_K8S_*` vars (`SERVICE_NAME`, `POD_IP`, `POD_UID`, `POD_NAME`, `DEPLOYMENT_METHOD`) are not part of the rename and are left untouched.
- **`Chart.yaml`**: version bump `0.7.0` → `0.7.1`.

## Testing

- `helm template` verified across 13 tag scenarios:
  - new names: `latest`, `stable`, `dev`, `2026`, `2026.07.0`, `2026.7`, `2026.12.0`, `2027.01.0`
  - legacy names: `2026.06.0`, `2026.06`, `2026.6.0`, `2025.12.0`, `0.14.0`, `1.4.0`
- `helm lint` passes (default and `2026.07.0`).

## Note (pre-existing, out of scope)

The security-context env var is gated on `.Values.lambda.securityContext` (camelCase) while `values.yaml` defines `lambda.security_context` (snake_case). This mismatch pre-dates this PR and means the var is not emitted when configured via the documented value; left unchanged here to keep the scope limited to the variable renaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)