### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# by default, add all repo maintainers as reviewers
-*       @alexrashed @lakkeger
+* @localstack/deployx


### PR DESCRIPTION
## Motivation
As discussed internally, the `CODEOWNERS` file is slightly outdated 😅 

## Changes
- Set @localstack/deployx as `CODEOWNER` globally.